### PR TITLE
feat: add a report job in workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Run Tests
         run: |
           pytest
-        continue-on-error: true
 
   report:
     needs: check
@@ -44,6 +43,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Report Results
         run: |
-          if grep -q '::error' $GITHUB_WORKSPACE/_actions/_workflows/check.yml; then
+          if [[ "${{ needs.check.result }}" == "failure" ]]; then
             exit 1
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,3 +35,15 @@ jobs:
         run: |
           pytest
         continue-on-error: true
+
+  report:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Report Results
+        run: |
+          if grep -q '::error' $GITHUB_WORKSPACE/_actions/_workflows/check.yml; then
+            exit 1
+          fi


### PR DESCRIPTION
使用 fail-fast 确保单个策略失败后，其他策略继续执行，并在所有策略执行完成后，通过 report job 决定整个工作流是否成功。