### PR TITLE
chore(ci): always set Codedev status to success

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project: #add everything under here, more options at https://docs.codecov.com/docs/commit-status
+      default:
+        # basic
+        target: auto #default
+        threshold: 0%
+        base: auto 
+        if_ci_failed: success

--- a/src/pystatpower/procedures/one_proportion.py
+++ b/src/pystatpower/procedures/one_proportion.py
@@ -437,3 +437,6 @@ def solve_for_proportion(
     if full_output:
         return model
     return model.proportion
+
+
+print("Done!")

--- a/src/pystatpower/procedures/one_proportion.py
+++ b/src/pystatpower/procedures/one_proportion.py
@@ -437,6 +437,3 @@ def solve_for_proportion(
     if full_output:
         return model
     return model.proportion
-
-
-print("Done!")


### PR DESCRIPTION
允许少量代码不被测试程序覆盖，主要包括一些执行概率极低或者理论上不可能执行的代码分支。

例如：
1. match case 不可能触发的断言分支：https://github.com/PyStatPower/PyStatPower/blob/00bcc18215ae876b5164f0e6562f93bfe94ea7e0/src/pystatpower/procedures/one_proportion.py#L268-L269
2. 过于苛刻的无解情况：https://github.com/PyStatPower/PyStatPower/blob/00bcc18215ae876b5164f0e6562f93bfe94ea7e0/src/pystatpower/procedures/one_proportion.py#L201-L202