### PR TITLE
chore(ci): pytest clear cache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run pytest and capture output
         run: |
-          pytest --color=no --cov --cov-report=xml | tee pytest_output.txt
+          pytest --cache-clear --color=no --cov --cov-report=xml | tee pytest_output.txt
 
           # 检查 pytest 的退出状态码
           if test ${PIPESTATUS[0]} -eq 0;  then


### PR DESCRIPTION
https://docs.pytest.org/en/stable/how-to/cache.html#clearing-cache-content

> This is recommended for invocations from Continuous Integration servers where isolation and correctness is more important than speed.
